### PR TITLE
Redirect to homepage after signed in

### DIFF
--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -25,7 +25,7 @@ export async function getServerSideProps({ locale, ...ctx }) {
   if (session) {
     return {
       redirect: {
-        destination: '/profile',
+        destination: '/',
         permanent: false,
       },
     };


### PR DESCRIPTION
Directly redirecting to profile page leads to permission problem on android device
so, I decided to redirect to homepage